### PR TITLE
[nbapagerank] fix csv string -> int casting comparison

### DIFF
--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -40,7 +40,7 @@ class NbaPagerank(object):
             matches_reader = csv.reader(matches_csv)
             return [
                 NbaMatch(match[2], match[4])
-                if match[3] > match[5]
+                if int(match[3]) > int(match[5])
                 else NbaMatch(match[4], match[2])
                 for match in matches_reader
             ]


### PR DESCRIPTION
python's csv reader doesn't type explicitly, handling that in the parser code directly. before we were comparing strings, meaning that `'99'` > `'100'` for scores. 🤡 

before:
```
Team: Los Angeles Lakers Win Count: 41 Wins: Phoenix Suns, Denver Nuggets, Dallas Mavericks, Portland Trail Blazers, Minnesota Timberwolves, Atlanta Hawks, Portland Trail Blazers, Cleveland Cavaliers, Utah Jazz, Denver Nuggets, Dallas Mavericks, San Antonio Spurs, Miami Heat, Charlotte Hornets, New Orleans Pelicans, Memphis Grizzlies, Golden State Warriors, Sacramento Kings, Minnesota Timberwolves, Detroit Pistons, Utah Jazz, Cleveland Cavaliers, Chicago Bulls, Oklahoma City Thunder, Phoenix Suns, Los Angeles Clippers, Indiana Pacers, Boston Celtics, Houston Rockets, New Orleans Pelicans, Denver Nuggets, Chicago Bulls, Toronto Raptors, Detroit Pistons, Sacramento Kings, Washington Wizards, Charlotte Hornets, New Orleans Pelicans, Golden State Warriors, Los Angeles Clippers, Utah Jazz
```

after:

```
Team: Los Angeles Lakers Win Count: 37 Wins: Phoenix Suns, Denver Nuggets, Dallas Mavericks, Portland Trail Blazers, Minnesota Timberwolves, Sacramento Kings, Atlanta Hawks, Portland Trail Blazers, Miami Heat, Cleveland Cavaliers, Utah Jazz, Indiana Pacers, Dallas Mavericks, Phoenix Suns, San Antonio Spurs, Memphis Grizzlies, Miami Heat, Charlotte Hornets, New Orleans Pelicans, Golden State Warriors, Sacramento Kings, Dallas Mavericks, Detroit Pistons, Chicago Bulls, Oklahoma City Thunder, Phoenix Suns, Los Angeles Clippers, Boston Celtics, Houston Rockets, New Orleans Pelicans, Chicago Bulls, Sacramento Kings, Washington Wizards, Charlotte Hornets, New Orleans Pelicans, Los Angeles Clippers, Utah Jazz
```


37 wins is correct.
