### PR TITLE
[nbapagerank] add PageRank logic; move PageRank logic into superclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# nba_pagerank
-@ronnyweasle and i attempt to bet on nba games
+# NBA Pagerank
+@ronnyweasle and i attempt to bet on nba games :basketball: :dollar:

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -35,7 +35,6 @@ class NbaPageRank(PageRank):
                 if i in j_loss_list:
                     M.itemset((i, j), 1 / float(len(j_loss_list)))
 
-        M = M
         R_0 = np.full((self.num_teams, 1), 1 / float(self.num_teams))
 
         super().__init__(M, R_0)

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -1,32 +1,80 @@
 import csv
+import numpy as np
 
+class PageRank(object):
+    def __init__(self, M, R):
+        if len(M) > 0:
+            assert len(M[0]) == len(M)
+        self.M = M
+        self.N = len(self.M) # M is a square matrix; N-by-N 2D array.
+        self.R_0 = np.full((self.N, 1), 1/float(self.N))
+        self.one_vector = np.ones((self.N, 1))
 
-class NbaPagerank(object):
+    # see https://en.wikipedia.org/wiki/PageRank#Iterative
+    def run(self, iterations=100, d=0.85):
+        R = self.R_0
+        for i in range(iterations):
+            R = np.add(self.d * np.matmul(self.M, R), (1 - self.d)/float(self.N) * self.one_vector)
+        return R
+
+class NbaPageRank(PageRank):
+    d = 0.85
     CSV_REGULAR_SEASON = 'data/2018_2019/regular_season.csv'
     CSV_PLAYOFFS = 'data/2018_2019/playoffs.csv'
 
+    def __init__(self, playoffs=False):
+        self.playoffs = playoffs
+        matches = self.matches_playoffs() if playoffs else self.matches_regular_season()
+        self.team_record_graph = self.build_graph(matches)
+        self.num_teams = len(self.team_record_graph)
 
-    def run(self):
-        matches_regular_season = self.matches_regular_season()
-        team_record_graph = self.build_graph(matches_regular_season)
-        for _, team_record in team_record_graph.items():
+        M = np.zeros((self.num_teams, self.num_teams))
+
+        for i in range(self.num_teams):
+            for j in range(self.num_teams):
+                # edge j -> i means j has lost to i
+                j_loss_list = self.team_record_graph[j].loss_list
+                if i in j_loss_list:
+                    M.itemset((i, j), 1 / float(len(j_loss_list)))
+
+        M = M
+        R_0 = np.full((self.num_teams, 1), 1/float(self.num_teams))
+
+        super().__init__(M, R_0)
+
+
+    def print_graph(self):
+        for _, team_record in self.team_record_graph.items():
             print(team_record)
-        pass
+        print(f"There are {self.num_teams} teams in total\n")
 
-    def run_iteration(self):
-        pass
+    def print_result(self, R, top=5):
+        assert(top <= self.num_teams)
+        flat = [score for score_list in R for score in score_list]
+        team_id_score = [(self.team_id_to_name[team_id], score) for team_id, score in enumerate(flat)]
+        score_sorted_desc = sorted(team_id_score, key=lambda x: x[1], reverse=True)
+        print(f"Top {top} in {'playoffs' if self.playoffs else 'regular season'} (desc):")
+        print(*score_sorted_desc[:top], sep='\n')
+        print()
 
     def is_finished(self):
         pass
 
     def build_graph(self, matches):
         team_to_team_record = {}
+        team_names = {match.loser for match in matches} | {match.winner for match in matches}
+        self.team_name_to_id = {team_name:i for i, team_name in enumerate(team_names)}
+        self.team_id_to_name = {i:team_name for i, team_name in enumerate(team_names)}
+
         for match in matches:
-            if match.loser not in team_to_team_record:
-                team_to_team_record[match.loser] = NbaTeamRecord(match.loser)
-            if match.winner not in team_to_team_record:
-                team_to_team_record[match.winner] = NbaTeamRecord(match.winner)
-            team_to_team_record[match.winner].record_win(match.loser)
+            loser_id = self.team_name_to_id[match.loser]
+            winner_id = self.team_name_to_id[match.winner]
+            if loser_id not in team_to_team_record:
+                team_to_team_record[loser_id] = NbaTeamRecord(loser_id, match.loser)
+            if winner_id not in team_to_team_record:
+                team_to_team_record[winner_id] = NbaTeamRecord(winner_id, match.winner)
+            team_to_team_record[winner_id].record_win(loser_id)
+            team_to_team_record[loser_id].record_loss(winner_id)
         return team_to_team_record
 
     def matches_regular_season(self):
@@ -52,22 +100,29 @@ class NbaMatch(object):
 
     def __repr__(self):
         return f"Winner: {self.winner} Loser: {self.loser}\n"
-    
-
 
 class NbaTeamRecord(object):
-    def __init__(self, team_id):
+    def __init__(self, team_id, team_name):
         self.team_id = team_id
+        self.team_name = team_name
         self.wins_list = []
+        self.loss_list = []
 
     def __repr__(self):
-        wins_list_formatted = ", ".join(self.wins_list)
+        wins_list_formatted = ", ".join(map(str, self.wins_list))
+        loss_list_formatted = ", ".join(map(str, self.loss_list))
         wins_count = len(self.wins_list)
-        return f"Team: {self.team_id} Win Count: {wins_count} Wins: {wins_list_formatted}\n"
+        loss_count = len(self.loss_list)
+        # assert(wins_count + loss_count == 82)
+        return f"Team: {self.team_name} Win Count: {wins_count} Wins: {wins_list_formatted}\n Loss Count: {loss_count} Losses: {loss_list_formatted}\n"
 
     def record_win(self, team_id_loser):
         self.wins_list.append(team_id_loser)
 
+    def record_loss(self, team_id_winner):
+        self.loss_list.append(team_id_winner)
 
-NbaPagerank().run()
-
+for use_playoffs_data in [False, True]:
+    nba_pagerank = NbaPageRank(playoffs=use_playoffs_data)
+    R = nba_pagerank.run(iterations=100, d=0.85)
+    nba_pagerank.print_result(R)

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -111,7 +111,6 @@ class NbaTeamRecord(object):
         loss_list_formatted = ", ".join(map(str, self.loss_list))
         wins_count = len(self.wins_list)
         loss_count = len(self.loss_list)
-        # assert(wins_count + loss_count == 82)
         return f"Team: {self.team_name} Win Count: {wins_count} Wins: {wins_list_formatted}\n Loss Count: {loss_count} Losses: {loss_list_formatted}\n"
 
     def record_win(self, team_id_loser):

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -2,7 +2,7 @@ import csv
 import numpy as np
 
 class PageRank(object):
-    def __init__(self, M, R):
+    def __init__(self, transition_matrix, ranks):
         assert len(M) > 0 and len(M[0]) == len(M)
         self.M = M
         self.N = len(self.M) # M is a square matrix; N-by-N 2D numpy array.

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -7,14 +7,14 @@ class PageRank(object):
             assert len(M[0]) == len(M)
         self.M = M
         self.N = len(self.M) # M is a square matrix; N-by-N 2D array.
-        self.R_0 = np.full((self.N, 1), 1/float(self.N))
+        self.R_0 = np.full((self.N, 1), 1 / float(self.N))
         self.one_vector = np.ones((self.N, 1))
 
     # see https://en.wikipedia.org/wiki/PageRank#Iterative
     def run(self, iterations=100, d=0.85):
         R = self.R_0
         for i in range(iterations):
-            R = np.add(d * np.matmul(self.M, R), (1 - d)/float(self.N) * self.one_vector)
+            R = np.add(d * np.matmul(self.M, R), (1 - d) / float(self.N) * self.one_vector)
         return R
 
 class NbaPageRank(PageRank):
@@ -37,7 +37,7 @@ class NbaPageRank(PageRank):
                     M.itemset((i, j), 1 / float(len(j_loss_list)))
 
         M = M
-        R_0 = np.full((self.num_teams, 1), 1/float(self.num_teams))
+        R_0 = np.full((self.num_teams, 1), 1 / float(self.num_teams))
 
         super().__init__(M, R_0)
 
@@ -62,8 +62,8 @@ class NbaPageRank(PageRank):
     def build_graph(self, matches):
         team_to_team_record = {}
         team_names = {match.loser for match in matches} | {match.winner for match in matches}
-        self.team_name_to_id = {team_name:i for i, team_name in enumerate(team_names)}
-        self.team_id_to_name = {i:team_name for i, team_name in enumerate(team_names)}
+        self.team_name_to_id = {team_name : i for i, team_name in enumerate(team_names)}
+        self.team_id_to_name = {i : team_name for i, team_name in enumerate(team_names)}
 
         for match in matches:
             loser_id = self.team_name_to_id[match.loser]

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -5,7 +5,7 @@ class PageRank(object):
     def __init__(self, transition_matrix, ranks):
         assert len(M) > 0 and len(M[0]) == len(M)
         self.M = M
-        self.N = len(self.M) # M is a square matrix; N-by-N 2D numpy array.
+        self.num_teams = len(self.M) # M is a square matrix; N-by-N 2D numpy array.
         self.R_0 = np.full((self.N, 1), 1 / float(self.N))
         self.one_vector = np.ones((self.N, 1))
 

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -20,8 +20,8 @@ class NbaPageRank(PageRank):
     CSV_REGULAR_SEASON = 'data/2018_2019/regular_season.csv'
     CSV_PLAYOFFS = 'data/2018_2019/playoffs.csv'
 
-    def __init__(self, playoffs=False):
-        self.playoffs = playoffs
+    def __init__(self, use_playoffs_data=False):
+        self.use_playoffs_data = use_playoffs_data
         matches = self.matches_playoffs() if playoffs else self.matches_regular_season()
         self.team_record_graph = self.build_graph(matches)
         self.num_teams = len(self.team_record_graph)

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -52,8 +52,7 @@ class NbaPageRank(PageRank):
         team_id_score = [(self.team_id_to_name[team_id], score) for team_id, score in enumerate(flat)]
         score_sorted_desc = sorted(team_id_score, key=lambda x: x[1], reverse=True)
         print(f"Top {top} in {'playoffs' if self.playoffs else 'regular season'} (desc):")
-        print(*score_sorted_desc[:top], sep='\n')
-        print()
+        print(*score_sorted_desc[:top], sep='\n', end='\n'*2)
 
     def is_finished(self):
         pass

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -10,7 +10,7 @@ class PageRank(object):
         self.one_vector = np.ones((self.N, 1))
 
     # see https://en.wikipedia.org/wiki/PageRank#Iterative
-    def run(self, iterations=100, d=0.85):
+    def run(self, iterations=100, damping_factor=0.85):
         R = self.R_0
         for i in range(iterations):
             R = np.add(d * np.matmul(self.M, R), (1 - d) / float(self.N) * self.one_vector)

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -3,8 +3,7 @@ import numpy as np
 
 class PageRank(object):
     def __init__(self, M, R):
-        if len(M) > 0:
-            assert len(M[0]) == len(M)
+        assert len(M) > 0 and len(M[0]) == len(M)
         self.M = M
         self.N = len(self.M) # M is a square matrix; N-by-N 2D numpy array.
         self.R_0 = np.full((self.N, 1), 1 / float(self.N))

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -24,7 +24,7 @@ class NbaPageRank(PageRank):
         self.use_playoffs_data = use_playoffs_data
         matches = self.matches_playoffs() if playoffs else self.matches_regular_season()
         self.team_record_graph = self.build_graph(matches)
-        self.num_teams = len(self.team_record_graph)
+        num_teams = len(self.team_record_graph)
 
         M = np.zeros((self.num_teams, self.num_teams))
 

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -62,8 +62,8 @@ class NbaPageRank(PageRank):
     def build_graph(self, matches):
         team_to_team_record = {}
         team_names = {match.loser for match in matches} | {match.winner for match in matches}
-        self.team_name_to_id = {team_name : i for i, team_name in enumerate(team_names)}
-        self.team_id_to_name = {i : team_name for i, team_name in enumerate(team_names)}
+        self.team_name_to_id = {team_name: i for i, team_name in enumerate(team_names)}
+        self.team_id_to_name = {i: team_name for i, team_name in enumerate(team_names)}
 
         for match in matches:
             loser_id = self.team_name_to_id[match.loser]

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -6,7 +6,7 @@ class PageRank(object):
         if len(M) > 0:
             assert len(M[0]) == len(M)
         self.M = M
-        self.N = len(self.M) # M is a square matrix; N-by-N 2D array.
+        self.N = len(self.M) # M is a square matrix; N-by-N 2D numpy array.
         self.R_0 = np.full((self.N, 1), 1 / float(self.N))
         self.one_vector = np.ones((self.N, 1))
 

--- a/nba_pagerank.py
+++ b/nba_pagerank.py
@@ -14,11 +14,10 @@ class PageRank(object):
     def run(self, iterations=100, d=0.85):
         R = self.R_0
         for i in range(iterations):
-            R = np.add(self.d * np.matmul(self.M, R), (1 - self.d)/float(self.N) * self.one_vector)
+            R = np.add(d * np.matmul(self.M, R), (1 - d)/float(self.N) * self.one_vector)
         return R
 
 class NbaPageRank(PageRank):
-    d = 0.85
     CSV_REGULAR_SEASON = 'data/2018_2019/regular_season.csv'
     CSV_PLAYOFFS = 'data/2018_2019/playoffs.csv'
 


### PR DESCRIPTION
We use the [iterative approach](https://en.wikipedia.org/wiki/PageRank#Iterative) from Wikipedia.

`100` iterations, damping factor `0.85`, 2018-2019 season:
```
/Users/rmeng/nba_pagerank $ python3 nba_pagerank.py
Top 5 in regular season (desc):
('Philadelphia 76ers', 0.011342068952168119)
('Houston Rockets', 0.011220608066890538)
('Golden State Warriors', 0.011218920207841456)
('Portland Trail Blazers', 0.011164389836479922)
('Milwaukee Bucks', 0.011150255412696063)

Top 5 in playoffs (desc):
('Toronto Raptors', 0.018790852863348317)
('Golden State Warriors', 0.017500406827584886)
('Milwaukee Bucks', 0.016370632043035415)
('Boston Celtics', 0.014150194947316022)
('Philadelphia 76ers', 0.013864573328212434)
```